### PR TITLE
Add Belief Trees Context and Exploratory Contexts

### DIFF
--- a/models/beliefs.proto
+++ b/models/beliefs.proto
@@ -3,15 +3,11 @@ syntax = "proto3";
 option go_package = "epistemic-me-core/pb/models";
 
 import "proto/models/predictive_processing.proto";
+import "proto/models/source.proto";
 
 // Base content and confidence messages
 message Content {
     string raw_str = 1;
-}
-
-message ConfidenceRating {
-    double confidence_score = 1;
-    bool default = 2;
 }
 
 // Belief types
@@ -64,7 +60,7 @@ message BeliefSystem {
 message BeliefTreeContext {
     // the current belief being looked at in this node of a Tree
     string belief_id = 1;
-    // the belief that this beleif was generated from. This is kept 
+    // the belief that this belief was generated from. This is kept 
     // as a list for optionality where this belief is linked to
     // other parent beleifs in the future. 
     repeated string parent_beliefs = 2;

--- a/models/dialectic.proto
+++ b/models/dialectic.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 option go_package = "epistemic-me-core/pb/models";
 
 import "proto/models/beliefs.proto";
-import "proto/models/source.proto";
+import "proto/models/predictive_processing.proto";
 
 // Add STATUS enum definition
 enum STATUS {

--- a/models/predictive_processing.proto
+++ b/models/predictive_processing.proto
@@ -71,6 +71,11 @@ message ObservationContext {
     repeated Source sources = 8;
 }
 
+message ConfidenceRating {
+    double confidence_score = 1;
+    bool default = 2;
+}
+
 // Types of epistemic emotions that emerge from discrepancies
 enum EpistemicEmotion {
     EMOTION_INVALID = 0;


### PR DESCRIPTION
Adds Two New Types of Epistemic Contexts. 

- Belief Trees for doing systematic generation of assumptions (modeled as supporting beliefs from a given belief)
- Exploratory Contexts for beginning "side quests" from a given belief