### PR TITLE
Feature/learning objective dialectic

### DIFF
--- a/epistemic_me.proto
+++ b/epistemic_me.proto
@@ -63,6 +63,7 @@ message CreateDialecticRequest {
     // to provide perspectives alongside each question and
     // answer dialectic 
     repeated string perspective_model_ids = 3;
+    LearningObjective learning_objective = 4;
 }
 
 // Response message for creating a new dialectic.

--- a/models/dialectic.proto
+++ b/models/dialectic.proto
@@ -150,6 +150,7 @@ message Dialectic {
     BeliefSystem belief_system = 5; // Add this line
     BeliefAnalysis analysis = 6;          // Analysis of the belief system
     LearningObjective learning_objective = 7; // What we want to learn about the user
+    repeated Perspective perspective_selves = 8; // Perspective selves
 }
 
 

--- a/models/dialectic.proto
+++ b/models/dialectic.proto
@@ -148,7 +148,8 @@ message Dialectic {
     Agent agent = 3;                      // The agent conducting the dialectic.
     repeated DialecticalInteraction user_interactions = 4; // Interactions within the dialectic.
     BeliefSystem belief_system = 5; // Add this line
-    BeliefAnalysis analysis = 6;  // Add this line
+    BeliefAnalysis analysis = 6;          // Analysis of the belief system
+    LearningObjective learning_objective = 7; // What we want to learn about the user
 }
 
 

--- a/models/dialectic.proto
+++ b/models/dialectic.proto
@@ -131,7 +131,7 @@ message LearningObjective {
     string description = 1;             // Natural language description of what to learn
     repeated string topics = 2;         // Key topics to explore (e.g., "sleep", "diet", "exercise")
     BeliefType target_belief_type = 3;  // Type of beliefs to collect
-    bool is_complete = 4;               // Whether we've collected enough beliefs
+    float completion_percentage = 4;     // Percentage of completion (0-100)
 }
 
 // The dialectic can be seen as a session that gets created

--- a/models/dialectic.proto
+++ b/models/dialectic.proto
@@ -150,7 +150,7 @@ message Dialectic {
     BeliefSystem belief_system = 5; // Add this line
     BeliefAnalysis analysis = 6;          // Analysis of the belief system
     LearningObjective learning_objective = 7; // What we want to learn about the user
-    repeated Perspective perspective_selves = 8; // Perspective selves
+    repeated string perspective_model_ids = 8; // IDs of perspective selves
 }
 
 

--- a/models/dialectic.proto
+++ b/models/dialectic.proto
@@ -111,7 +111,6 @@ enum DialecticType {
 // be some AI system (e.g., LLM) but may evolve to be a human
 // user in the future.
 message Agent {
-
     // Labels the system that is driving the agent's behavior.
     // This may include generating the question, synthesizing
     // the user's answers into beliefs, and then synthesizing
@@ -125,6 +124,14 @@ message Agent {
 
     AgentType agent_type = 1;             // The type of the agent.
     DialecticType dialectic_type = 2;     // The dialectic strategy used by the agent.
+}
+
+// LearningObjective represents what we want to learn about the user
+message LearningObjective {
+    string description = 1;             // Natural language description of what to learn
+    repeated string topics = 2;         // Key topics to explore (e.g., "sleep", "diet", "exercise")
+    BeliefType target_belief_type = 3;  // Type of beliefs to collect
+    bool is_complete = 4;               // Whether we've collected enough beliefs
 }
 
 // The dialectic can be seen as a session that gets created


### PR DESCRIPTION
The PR adds a Learning Objective to a Dialectic. It is intended to move the SDK towards a modality of Dialectic design where the Developer can specify what they want to learn about their users, and then train a Question-Answer Dialectic to ask questions of their user until the LearningObjective for the dialectic is complete.

The Learning Objective can specify the BeliefType it needs to collect in order to fulfill the learning specification of the Dialectic.