### PR TITLE
Update philosophy with extrapolate context

### DIFF
--- a/epistemic_me.proto
+++ b/epistemic_me.proto
@@ -23,6 +23,7 @@ service EpistemicMeService {
     rpc CreateUser(CreateUserRequest) returns (CreateUserResponse) {}
     rpc GetDeveloper(GetDeveloperRequest) returns (GetDeveloperResponse);
     rpc PreprocessQuestionAnswer(PreprocessQuestionAnswerRequest) returns (PreprocessQuestionAnswerResponse) {}
+    rpc UpdatePhilosophy(UpdatePhilosophyRequest) returns (UpdatePhilosophyResponse) {}
 }
 
 // Request message for listing beliefs.
@@ -190,4 +191,14 @@ message PreprocessQuestionAnswerResponse {
 message QuestionAnswerPair {
     string question = 1;
     string answer = 2;
+}
+
+message UpdatePhilosophyRequest {
+    string philosophy_id = 1;
+    string description = 2;
+    bool extrapolate_contexts = 3;
+}
+
+message UpdatePhilosophyResponse {
+    Philosophy philosophy = 1;
 }

--- a/epistemic_me.proto
+++ b/epistemic_me.proto
@@ -7,6 +7,7 @@ import "proto/models/dialectic.proto";
 import "proto/models/self_model.proto";
 import "proto/models/developer.proto";
 import "proto/models/user.proto";
+import "proto/models/predictive_processing.proto";
 
 service EpistemicMeService {
     rpc CreateBelief(CreateBeliefRequest) returns (CreateBeliefResponse) {}
@@ -151,6 +152,7 @@ message CreatePhilosophyRequest {
 
 message CreatePhilosophyResponse {
     Philosophy philosophy = 1;
+    repeated ObservationContext extrapolated_observation_contexts = 2;
 }
 
 message CreateDeveloperRequest {
@@ -202,4 +204,5 @@ message UpdatePhilosophyRequest {
 
 message UpdatePhilosophyResponse {
     Philosophy philosophy = 1;
+    repeated ObservationContext extrapolated_observation_contexts = 2;
 }

--- a/epistemic_me.proto
+++ b/epistemic_me.proto
@@ -19,6 +19,7 @@ service EpistemicMeService {
     rpc CreateSelfModel(CreateSelfModelRequest) returns (CreateSelfModelResponse) {}
     rpc GetSelfModel(GetSelfModelRequest) returns (GetSelfModelResponse) {}
     rpc AddPhilosophy(AddPhilosophyRequest) returns (AddPhilosophyResponse) {}
+    rpc CreatePhilosophy(CreatePhilosophyRequest) returns (CreatePhilosophyResponse) {}
     rpc CreateDeveloper(CreateDeveloperRequest) returns (CreateDeveloperResponse) {}
     rpc CreateUser(CreateUserRequest) returns (CreateUserResponse) {}
     rpc GetDeveloper(GetDeveloperRequest) returns (GetDeveloperResponse);


### PR DESCRIPTION
### Overview

This PR enhances the EpistemicMe proto definitions to support observation context extraction when creating or updating a philosophy. It introduces new fields and updates service definitions to ensure that both the creation and update of philosophies can return extrapolated observation contexts.

### Key Changes

- **Service Updates:**
  - `UpdatePhilosophy` and `CreatePhilosophy` RPCs now return a list of `ObservationContext` objects that are extrapolated from the philosophy description.

- **Message Updates:**
  - `CreatePhilosophyResponse` and new `UpdatePhilosophyResponse` both include:
    - `repeated ObservationContext extrapolated_observation_contexts`
  - `UpdatePhilosophyRequest` now supports:
    - `philosophy_id` (string)
    - `description` (string)
    - `extrapolate_contexts` (bool)

- **Motivation:**
  - Enables clients to receive and utilize observation contexts parsed from philosophy narratives, supporting richer downstream processing and UI features.
  - Aligns proto definitions with SDK and backend expectations for observation context handling.
